### PR TITLE
Camp turns

### DIFF
--- a/Scenes/Camps/test_level.tscn
+++ b/Scenes/Camps/test_level.tscn
@@ -98,6 +98,7 @@ scale = Vector2(0.431655, 0.336504)
 text = "Discard"
 
 [node name="EndOfTurnPopup" type="Control" parent="CanvasLayer"]
+process_mode = 2
 z_index = 10
 layout_mode = 3
 anchors_preset = 0
@@ -116,6 +117,16 @@ offset_bottom = -31.0
 scale = Vector2(0.607645, 0.477497)
 text = "How many biscuits do you want to eat while travelling?"
 
+[node name="NumberOfBiscuitsLabel" type="Label" parent="CanvasLayer/EndOfTurnPopup"]
+layout_mode = 0
+offset_left = -300.667
+offset_top = -198.333
+offset_right = -274.667
+offset_bottom = -171.333
+scale = Vector2(0.607645, 0.477497)
+text = "0"
+horizontal_alignment = 1
+
 [node name="AdvanceButton" type="Button" parent="CanvasLayer/EndOfTurnPopup"]
 layout_mode = 0
 offset_left = -317.667
@@ -125,13 +136,16 @@ offset_bottom = -120.0
 scale = Vector2(0.352649, 0.583948)
 text = "Advance"
 
-[node name="NumberOfBiscuits" type="LineEdit" parent="CanvasLayer/EndOfTurnPopup"]
+[node name="NumberOfBiscuitsSlider" type="HSlider" parent="CanvasLayer/EndOfTurnPopup"]
 layout_mode = 0
-offset_left = -311.667
-offset_top = -181.333
-offset_right = -217.667
-offset_bottom = -150.333
-scale = Vector2(0.378777, 0.399956)
+offset_left = -359.0
+offset_top = -187.667
+offset_right = -231.0
+offset_bottom = -171.667
+scale = Vector2(1.05991, 1)
+rounded = true
+scrollable = false
+ticks_on_borders = true
 
 [node name="PauseMenu" type="Control" parent="CanvasLayer"]
 process_mode = 3
@@ -189,5 +203,6 @@ scale = Vector2(60.56, 1)
 [connection signal="pressed" from="CanvasLayer/Control/DiscardButton" to="CanvasLayer/Control" method="_on_discard_button_pressed"]
 [connection signal="pressed" from="CanvasLayer/EndOfTurnPopup/AdvanceButton" to="CanvasLayer/EndOfTurnPopup" method="_on_advance_button_pressed"]
 [connection signal="pressed" from="CanvasLayer/EndOfTurnPopup/AdvanceButton" to="CanvasLayer/EndOfTurnPopup/AdvanceButton" method="_on_pressed"]
+[connection signal="value_changed" from="CanvasLayer/EndOfTurnPopup/NumberOfBiscuitsSlider" to="CanvasLayer/EndOfTurnPopup" method="_on_number_of_biscuits_slider_value_changed"]
 [connection signal="pressed" from="CanvasLayer/PauseMenu/ResumeButton" to="CanvasLayer/PauseMenu" method="_on_resume_button_pressed"]
 [connection signal="pressed" from="CanvasLayer/PauseMenu/ResumeButton" to="CanvasLayer/PauseMenu/ResumeButton" method="_on_pressed"]

--- a/Scenes/Camps/test_level.tscn
+++ b/Scenes/Camps/test_level.tscn
@@ -15,7 +15,7 @@
 [node name="TestLevel" type="Node2D"]
 
 [node name="CampTemp" type="Sprite2D" parent="."]
-position = Vector2(579, 319.5)
+position = Vector2(569, 321)
 scale = Vector2(1.82813, 2.02813)
 texture = ExtResource("1_c4fu7")
 
@@ -88,6 +88,16 @@ scale = Vector2(0.607645, 0.477497)
 text = "Biscuits: 
 Turn: "
 
+[node name="TimeRemainingLabel" type="Label" parent="CanvasLayer/Control"]
+layout_mode = 0
+offset_left = -240.667
+offset_top = -268.0
+offset_right = -16.6667
+offset_bottom = -88.0
+scale = Vector2(0.607645, 0.477497)
+text = "Time remaining:
+"
+
 [node name="DiscardButton" type="Button" parent="CanvasLayer/Control"]
 layout_mode = 0
 offset_left = -361.333
@@ -96,6 +106,10 @@ offset_right = -294.333
 offset_bottom = -259.333
 scale = Vector2(0.431655, 0.336504)
 text = "Discard"
+
+[node name="CampTimer" type="Timer" parent="CanvasLayer/Control"]
+wait_time = 60.0
+autostart = true
 
 [node name="EndOfTurnPopup" type="Control" parent="CanvasLayer"]
 process_mode = 2
@@ -198,9 +212,11 @@ scale = Vector2(59.0067, 0.875)
 position = Vector2(592, 655)
 scale = Vector2(60.56, 1)
 
+[connection signal="pressed" from="CanvasLayer/Control/EndTurnButton" to="CanvasLayer/Control" method="_on_end_turn_button_pressed"]
 [connection signal="pressed" from="CanvasLayer/Control/EndTurnButton" to="CanvasLayer/Control/EndTurnButton" method="_on_pressed"]
 [connection signal="pressed" from="CanvasLayer/Control/EndTurnButton" to="CanvasLayer/EndOfTurnPopup" method="_on_end_turn_button_pressed"]
 [connection signal="pressed" from="CanvasLayer/Control/DiscardButton" to="CanvasLayer/Control" method="_on_discard_button_pressed"]
+[connection signal="timeout" from="CanvasLayer/Control/CampTimer" to="CanvasLayer/Control" method="_on_camp_timer_timeout"]
 [connection signal="pressed" from="CanvasLayer/EndOfTurnPopup/AdvanceButton" to="CanvasLayer/EndOfTurnPopup" method="_on_advance_button_pressed"]
 [connection signal="pressed" from="CanvasLayer/EndOfTurnPopup/AdvanceButton" to="CanvasLayer/EndOfTurnPopup/AdvanceButton" method="_on_pressed"]
 [connection signal="value_changed" from="CanvasLayer/EndOfTurnPopup/NumberOfBiscuitsSlider" to="CanvasLayer/EndOfTurnPopup" method="_on_number_of_biscuits_slider_value_changed"]

--- a/Scenes/Camps/test_level.tscn
+++ b/Scenes/Camps/test_level.tscn
@@ -103,6 +103,76 @@ offset_bottom = -259.333
 scale = Vector2(0.431655, 0.336504)
 text = "Discard"
 
+[node name="EndOfTurnPopup" type="Control" parent="CanvasLayer"]
+z_index = 10
+layout_mode = 3
+anchors_preset = 0
+offset_left = 455.0
+offset_top = 294.0
+offset_right = 495.0
+offset_bottom = 334.0
+script = ExtResource("3_qq1j0")
+
+[node name="EndOfTurnLabel" type="Label" parent="CanvasLayer/EndOfTurnPopup"]
+layout_mode = 0
+offset_left = -452.0
+offset_top = -291.0
+offset_right = -228.0
+offset_bottom = -111.0
+scale = Vector2(0.607645, 0.477497)
+text = "Biscuits: 
+Turn: "
+
+[node name="EndTurnButton" type="Button" parent="CanvasLayer/EndOfTurnPopup"]
+layout_mode = 0
+offset_left = -122.667
+offset_top = -100.667
+offset_right = 6.33334
+offset_bottom = -69.6667
+scale = Vector2(0.352649, 0.583948)
+text = "End Turn"
+
+[node name="LineEdit" type="LineEdit" parent="CanvasLayer/EndOfTurnPopup"]
+layout_mode = 0
+offset_left = -118.0
+offset_top = -118.0
+offset_right = -24.0
+offset_bottom = -87.0
+scale = Vector2(0.378777, 0.399956)
+
+[node name="Pause Menu" type="Control" parent="CanvasLayer"]
+process_mode = 3
+visible = false
+top_level = true
+z_index = 10
+layout_mode = 3
+anchors_preset = 0
+offset_left = 455.0
+offset_top = 294.0
+offset_right = 495.0
+offset_bottom = 334.0
+script = ExtResource("3_qq1j0")
+
+[node name="PauseLabel" type="Label" parent="CanvasLayer/Pause Menu"]
+layout_mode = 0
+offset_left = -345.0
+offset_top = -231.0
+offset_right = -121.0
+offset_bottom = -51.0
+scale = Vector2(0.607645, 0.477497)
+text = "GAME PAUSED"
+horizontal_alignment = 1
+vertical_alignment = 1
+
+[node name="ResumeButton" type="Button" parent="CanvasLayer/Pause Menu"]
+layout_mode = 0
+offset_left = -301.0
+offset_top = -178.667
+offset_right = -172.0
+offset_bottom = -147.666
+scale = Vector2(0.352649, 0.583948)
+text = "Resume"
+
 [node name="InvisibleWalls" type="Node" parent="."]
 
 [node name="InvisibleWall" parent="InvisibleWalls" instance=ExtResource("9_o16nm")]
@@ -124,3 +194,8 @@ scale = Vector2(60.56, 1)
 [connection signal="pressed" from="CanvasLayer/Control/EndTurnButton" to="CanvasLayer/Control" method="_on_end_turn_button_pressed"]
 [connection signal="pressed" from="CanvasLayer/Control/EndTurnButton" to="CanvasLayer/Control/EndTurnButton" method="_on_pressed"]
 [connection signal="pressed" from="CanvasLayer/Control/DiscardButton" to="CanvasLayer/Control" method="_on_discard_button_pressed"]
+[connection signal="pressed" from="CanvasLayer/EndOfTurnPopup/EndTurnButton" to="CanvasLayer/EndOfTurnPopup" method="_on_end_turn_button_pressed"]
+[connection signal="pressed" from="CanvasLayer/EndOfTurnPopup/EndTurnButton" to="CanvasLayer/EndOfTurnPopup/EndTurnButton" method="_on_pressed"]
+[connection signal="pressed" from="CanvasLayer/Pause Menu/ResumeButton" to="CanvasLayer/EndOfTurnPopup" method="_on_end_turn_button_pressed"]
+[connection signal="pressed" from="CanvasLayer/Pause Menu/ResumeButton" to="CanvasLayer/Pause Menu" method="_on_resume_button_pressed"]
+[connection signal="pressed" from="CanvasLayer/Pause Menu/ResumeButton" to="CanvasLayer/Pause Menu/ResumeButton" method="_on_pressed"]

--- a/Scenes/Camps/test_level.tscn
+++ b/Scenes/Camps/test_level.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=10 format=3 uid="uid://deqbbtwchr357"]
+[gd_scene load_steps=12 format=3 uid="uid://deqbbtwchr357"]
 
 [ext_resource type="Texture2D" uid="uid://c8g4gvm87meby" path="res://Assets/Camp/Camp_temp.png" id="1_c4fu7"]
 [ext_resource type="PackedScene" uid="uid://uldm21fmtwyx" path="res://Scenes/Player/player.tscn" id="2_yqnp2"]
@@ -9,6 +9,8 @@
 [ext_resource type="PackedScene" uid="uid://doy4bb45g1085" path="res://Scenes/Stations/mortar_and_pestle.tscn" id="8_o16nm"]
 [ext_resource type="PackedScene" uid="uid://d4d4b0g6aw2th" path="res://Scenes/Stations/wheat.tscn" id="8_tol5k"]
 [ext_resource type="PackedScene" uid="uid://c1xml0p8585f2" path="res://Scenes/invisible_wall.tscn" id="9_o16nm"]
+[ext_resource type="Script" uid="uid://sluadc1scs3u" path="res://Scripts/GUI_end_turn.gd" id="9_tol5k"]
+[ext_resource type="Script" uid="uid://gpyh2lxkqtod" path="res://Scripts/GUI_pause_menu.gd" id="10_63ecn"]
 
 [node name="TestLevel" type="Node2D"]
 
@@ -86,14 +88,6 @@ scale = Vector2(0.607645, 0.477497)
 text = "Biscuits: 
 Turn: "
 
-[node name="LineEdit" type="LineEdit" parent="CanvasLayer/Control"]
-layout_mode = 0
-offset_left = -118.0
-offset_top = -118.0
-offset_right = -24.0
-offset_bottom = -87.0
-scale = Vector2(0.378777, 0.399956)
-
 [node name="DiscardButton" type="Button" parent="CanvasLayer/Control"]
 layout_mode = 0
 offset_left = -361.333
@@ -111,36 +105,35 @@ offset_left = 455.0
 offset_top = 294.0
 offset_right = 495.0
 offset_bottom = 334.0
-script = ExtResource("3_qq1j0")
+script = ExtResource("9_tol5k")
 
 [node name="EndOfTurnLabel" type="Label" parent="CanvasLayer/EndOfTurnPopup"]
 layout_mode = 0
-offset_left = -452.0
-offset_top = -291.0
-offset_right = -228.0
-offset_bottom = -111.0
+offset_left = -404.667
+offset_top = -211.0
+offset_right = 25.3333
+offset_bottom = -31.0
 scale = Vector2(0.607645, 0.477497)
-text = "Biscuits: 
-Turn: "
+text = "How many biscuits do you want to eat while travelling?"
 
-[node name="EndTurnButton" type="Button" parent="CanvasLayer/EndOfTurnPopup"]
+[node name="AdvanceButton" type="Button" parent="CanvasLayer/EndOfTurnPopup"]
 layout_mode = 0
-offset_left = -122.667
-offset_top = -100.667
-offset_right = 6.33334
-offset_bottom = -69.6667
+offset_left = -317.667
+offset_top = -151.0
+offset_right = -188.666
+offset_bottom = -120.0
 scale = Vector2(0.352649, 0.583948)
-text = "End Turn"
+text = "Advance"
 
-[node name="LineEdit" type="LineEdit" parent="CanvasLayer/EndOfTurnPopup"]
+[node name="NumberOfBiscuits" type="LineEdit" parent="CanvasLayer/EndOfTurnPopup"]
 layout_mode = 0
-offset_left = -118.0
-offset_top = -118.0
-offset_right = -24.0
-offset_bottom = -87.0
+offset_left = -311.667
+offset_top = -181.333
+offset_right = -217.667
+offset_bottom = -150.333
 scale = Vector2(0.378777, 0.399956)
 
-[node name="Pause Menu" type="Control" parent="CanvasLayer"]
+[node name="PauseMenu" type="Control" parent="CanvasLayer"]
 process_mode = 3
 visible = false
 top_level = true
@@ -151,9 +144,9 @@ offset_left = 455.0
 offset_top = 294.0
 offset_right = 495.0
 offset_bottom = 334.0
-script = ExtResource("3_qq1j0")
+script = ExtResource("10_63ecn")
 
-[node name="PauseLabel" type="Label" parent="CanvasLayer/Pause Menu"]
+[node name="PauseLabel" type="Label" parent="CanvasLayer/PauseMenu"]
 layout_mode = 0
 offset_left = -345.0
 offset_top = -231.0
@@ -164,7 +157,7 @@ text = "GAME PAUSED"
 horizontal_alignment = 1
 vertical_alignment = 1
 
-[node name="ResumeButton" type="Button" parent="CanvasLayer/Pause Menu"]
+[node name="ResumeButton" type="Button" parent="CanvasLayer/PauseMenu"]
 layout_mode = 0
 offset_left = -301.0
 offset_top = -178.667
@@ -191,11 +184,10 @@ scale = Vector2(59.0067, 0.875)
 position = Vector2(592, 655)
 scale = Vector2(60.56, 1)
 
-[connection signal="pressed" from="CanvasLayer/Control/EndTurnButton" to="CanvasLayer/Control" method="_on_end_turn_button_pressed"]
 [connection signal="pressed" from="CanvasLayer/Control/EndTurnButton" to="CanvasLayer/Control/EndTurnButton" method="_on_pressed"]
+[connection signal="pressed" from="CanvasLayer/Control/EndTurnButton" to="CanvasLayer/EndOfTurnPopup" method="_on_end_turn_button_pressed"]
 [connection signal="pressed" from="CanvasLayer/Control/DiscardButton" to="CanvasLayer/Control" method="_on_discard_button_pressed"]
-[connection signal="pressed" from="CanvasLayer/EndOfTurnPopup/EndTurnButton" to="CanvasLayer/EndOfTurnPopup" method="_on_end_turn_button_pressed"]
-[connection signal="pressed" from="CanvasLayer/EndOfTurnPopup/EndTurnButton" to="CanvasLayer/EndOfTurnPopup/EndTurnButton" method="_on_pressed"]
-[connection signal="pressed" from="CanvasLayer/Pause Menu/ResumeButton" to="CanvasLayer/EndOfTurnPopup" method="_on_end_turn_button_pressed"]
-[connection signal="pressed" from="CanvasLayer/Pause Menu/ResumeButton" to="CanvasLayer/Pause Menu" method="_on_resume_button_pressed"]
-[connection signal="pressed" from="CanvasLayer/Pause Menu/ResumeButton" to="CanvasLayer/Pause Menu/ResumeButton" method="_on_pressed"]
+[connection signal="pressed" from="CanvasLayer/EndOfTurnPopup/AdvanceButton" to="CanvasLayer/EndOfTurnPopup" method="_on_advance_button_pressed"]
+[connection signal="pressed" from="CanvasLayer/EndOfTurnPopup/AdvanceButton" to="CanvasLayer/EndOfTurnPopup/AdvanceButton" method="_on_pressed"]
+[connection signal="pressed" from="CanvasLayer/PauseMenu/ResumeButton" to="CanvasLayer/PauseMenu" method="_on_resume_button_pressed"]
+[connection signal="pressed" from="CanvasLayer/PauseMenu/ResumeButton" to="CanvasLayer/PauseMenu/ResumeButton" method="_on_pressed"]

--- a/Scripts/GUI.gd
+++ b/Scripts/GUI.gd
@@ -2,11 +2,14 @@ extends Control
 
 
 func _process(delta: float) -> void:
-	#var GameManagerLabel = get_node("CanvasLayer/Control/GameManagerLabel")
 	$GameManagerLabel.text = "Inventory: " + str(GameManager.inventory_string()) + "\nBiscuits: " + str(GameManager.biscuits) + "\nTurn: " + str(GameManager.turn) + "\nPlayer Distance: " + str(GameManager.player_distance) + "\nWinter Distance: " + str(GameManager.winter_distance)
+	$TimeRemainingLabel.text = "Time Remaining:\n" + str(snapped($CampTimer.time_left, 0.01))
 
 func _on_end_turn_button_pressed() -> void:
-	GameManager.next_turn(int($LineEdit.text))
+	$CampTimer.start()
 
 func _on_discard_button_pressed() -> void:
 	GameManager.discard_item_sig.emit()
+
+func _on_camp_timer_timeout() -> void:
+	$EndTurnButton.pressed.emit()

--- a/Scripts/GUI.gd
+++ b/Scripts/GUI.gd
@@ -1,11 +1,12 @@
 extends Control
 
 
-func _input(event: InputEvent) -> void:
-	if Input.is_key_pressed(KEY_ESCAPE):
-		get_tree().paused = true
-		show()
+func _process(delta: float) -> void:
+	#var GameManagerLabel = get_node("CanvasLayer/Control/GameManagerLabel")
+	$GameManagerLabel.text = "Inventory: " + str(GameManager.inventory_string()) + "\nBiscuits: " + str(GameManager.biscuits) + "\nTurn: " + str(GameManager.turn) + "\nPlayer Distance: " + str(GameManager.player_distance) + "\nWinter Distance: " + str(GameManager.winter_distance)
 
-func _on_resume_button_pressed() -> void:
-	get_tree().paused = false
-	hide()
+func _on_end_turn_button_pressed() -> void:
+	GameManager.next_turn(int($LineEdit.text))
+
+func _on_discard_button_pressed() -> void:
+	GameManager.discard_item_sig.emit()

--- a/Scripts/GUI.gd
+++ b/Scripts/GUI.gd
@@ -1,10 +1,11 @@
 extends Control
 
-func _process(delta: float) -> void:
-	$GameManagerLabel.text = "Inventory: " + str(GameManager.inventory_string()) + "\nBiscuits: " + str(GameManager.biscuits) + "\nTurn: " + str(GameManager.turn) + "\nPlayer Distance: " + str(GameManager.player_distance) + "\nWinter Distance: " + str(GameManager.winter_distance)
 
-func _on_end_turn_button_pressed() -> void:
-	GameManager.next_turn(int($LineEdit.text))
+func _input(event: InputEvent) -> void:
+	if Input.is_key_pressed(KEY_ESCAPE):
+		get_tree().paused = true
+		show()
 
-func _on_discard_button_pressed() -> void:
-	GameManager.discard_item_sig.emit()
+func _on_resume_button_pressed() -> void:
+	get_tree().paused = false
+	hide()

--- a/Scripts/GUI_end_turn.gd
+++ b/Scripts/GUI_end_turn.gd
@@ -1,0 +1,16 @@
+extends Control
+
+#@onready var end_turn_menu = $PauseMenu
+
+func _init() -> void:
+	self.hide()
+
+func _on_end_turn_button_pressed() -> void:
+	self.show()
+	
+
+func _on_advance_button_pressed() -> void:
+	var textBox = $NumberOfBiscuits
+	var num_biscuits = int(textBox.text)
+	self.hide()
+	GameManager.next_turn(num_biscuits)

--- a/Scripts/GUI_end_turn.gd
+++ b/Scripts/GUI_end_turn.gd
@@ -7,10 +7,19 @@ func _init() -> void:
 
 func _on_end_turn_button_pressed() -> void:
 	self.show()
+	# set the slider's max value to the number of biscuits you have
+	$NumberOfBiscuitsSlider.max_value = GameManager.biscuits
+	$NumberOfBiscuitsSlider.tick_count = GameManager.biscuits
+	get_tree().paused = true
 	
 
 func _on_advance_button_pressed() -> void:
-	var textBox = $NumberOfBiscuits
+	var textBox = $NumberOfBiscuitsLabel
 	var num_biscuits = int(textBox.text)
 	self.hide()
+	get_tree().paused = false
 	GameManager.next_turn(num_biscuits)
+
+
+func _on_number_of_biscuits_slider_value_changed(value: float) -> void:
+	$NumberOfBiscuitsLabel.text = str(int(value))

--- a/Scripts/GUI_end_turn.gd.uid
+++ b/Scripts/GUI_end_turn.gd.uid
@@ -1,0 +1,1 @@
+uid://sluadc1scs3u

--- a/Scripts/GUI_pause_menu.gd
+++ b/Scripts/GUI_pause_menu.gd
@@ -1,0 +1,11 @@
+extends Control
+
+
+func _input(event: InputEvent) -> void:
+	if Input.is_key_pressed(KEY_ESCAPE):
+		get_tree().paused = true
+		self.show()
+
+func _on_resume_button_pressed() -> void:
+	get_tree().paused = false
+	self.hide()

--- a/Scripts/GUI_pause_menu.gd.uid
+++ b/Scripts/GUI_pause_menu.gd.uid
@@ -1,0 +1,1 @@
+uid://gpyh2lxkqtod

--- a/game_manager.gd
+++ b/game_manager.gd
@@ -52,22 +52,18 @@ func gain_biscuit(num_biscuits: int) -> void:
 func gain_dough() -> void:
 	if inventory == Items.EMPTY:
 		inventory = Items.DOUGH
-	print(inventory)
 
 func gain_water() -> void:
 	if inventory == Items.EMPTY:
 		inventory = Items.WATER
-	print(inventory)
 	
 func gain_wheat() -> void:
 	if inventory == Items.EMPTY:
 		inventory = Items.WHEAT
-	print(inventory)
 
 func gain_flour() -> void:
 	if inventory == Items.EMPTY:
 		inventory = Items.FLOUR
-	print(inventory)
 	
 func discard_item() -> void:
 	inventory = Items.EMPTY

--- a/game_manager.gd
+++ b/game_manager.gd
@@ -13,6 +13,8 @@ enum Items {EMPTY, WHEAT, FLOUR, WATER, DOUGH}
 
 @export var distance_per_biscuit: int = 100
 
+@export var camp_timer : Timer
+
 var rng = RandomNumberGenerator.new()
 
 var my_array = [100, 200, 300, 400, 500]
@@ -24,11 +26,13 @@ func _ready() -> void:
 	discard_item_sig.connect(discard_item)	
 
 func initialise_vars() -> void:
-	biscuits = 10
+	biscuits = 0
 	inventory = Items.EMPTY
 	turn = 1
 	player_distance = 1000
 	winter_distance = 0
+	# camp timer starts automatically upon entering the scene
+	
 
 func inventory_string() -> String:
 	match inventory:
@@ -79,3 +83,4 @@ func next_turn(consume_num_biscuits: int) -> void:
 		get_tree().change_scene_to_file("res://Scenes/Screens/game_over_screen.tscn")
 	else:
 		turn += 1
+		# load the map screen which will in turn load a camp scene and restart the timer

--- a/game_manager.gd
+++ b/game_manager.gd
@@ -24,7 +24,7 @@ func _ready() -> void:
 	discard_item_sig.connect(discard_item)	
 
 func initialise_vars() -> void:
-	biscuits = 0
+	biscuits = 10
 	inventory = Items.EMPTY
 	turn = 1
 	player_distance = 1000


### PR DESCRIPTION
Add a sixty second turn timer that forces the player to end their turn when it runs out (the option still exists to end the turn early if you like). 
Added a rudimentary pause menu with the Esc key
Moved the "how many biscuits are you eating" to a separate popup that appears when your turn ends, and the number of biscuits is added with a slider instead of a text box
Entering the number of biscuits and clicking "Advance" triggers the existing next_turn code so this should slot in without much disruption