### PR TITLE
Dough and Busy fixes

### DIFF
--- a/Scenes/Stations/mixing_bowl.tscn
+++ b/Scenes/Stations/mixing_bowl.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=11 format=3 uid="uid://bhgsnpk41ol4b"]
+[gd_scene load_steps=12 format=3 uid="uid://bhgsnpk41ol4b"]
 
 [ext_resource type="Script" uid="uid://o75kjk20mkx4" path="res://Scripts/mixing_bowl.gd" id="1_p7i4k"]
 [ext_resource type="Texture2D" uid="uid://dv4oiy8g7aqmj" path="res://Assets/Stations/MixingBowl.png" id="2_p7i4k"]
@@ -7,6 +7,7 @@
 [ext_resource type="Texture2D" uid="uid://0h57n21pgy7u" path="res://Assets/Clocks/clock_progress_over.png" id="5_n08vg"]
 [ext_resource type="Texture2D" uid="uid://6o5jijuospyl" path="res://Assets/ItemBoxes/Flour_Item_Background_Temp.png" id="6_nuxqa"]
 [ext_resource type="Texture2D" uid="uid://bq23pqscjxg6v" path="res://Assets/ItemBoxes/Water_Item_Background_Temp.png" id="7_gargd"]
+[ext_resource type="Texture2D" uid="uid://c1d661tfkkm3p" path="res://Assets/ItemBoxes/Dough_Item_Background_Temp.png" id="8_gargd"]
 
 [sub_resource type="AtlasTexture" id="AtlasTexture_0js8q"]
 atlas = ExtResource("2_p7i4k")
@@ -76,6 +77,11 @@ texture = ExtResource("6_nuxqa")
 position = Vector2(-24, -17)
 scale = Vector2(0.851394, 0.82494)
 texture = ExtResource("7_gargd")
+
+[node name="DoughItemSprite" type="Sprite2D" parent="."]
+position = Vector2(-1, -17)
+scale = Vector2(0.851394, 0.82494)
+texture = ExtResource("8_gargd")
 
 [connection signal="body_entered" from="ProximityTrigger" to="." method="_on_proximity_trigger_body_entered"]
 [connection signal="body_exited" from="ProximityTrigger" to="." method="_on_proximity_trigger_body_exited"]

--- a/Scenes/Stations/mortar_and_pestle.tscn
+++ b/Scenes/Stations/mortar_and_pestle.tscn
@@ -5,7 +5,7 @@
 [ext_resource type="PackedScene" uid="uid://b81j4cgq1flrb" path="res://Scenes/Stations/proximity_trigger.tscn" id="3_5wmxq"]
 [ext_resource type="Texture2D" uid="uid://cp1x0niouvpps" path="res://Assets/Clocks/clock_progress_under.png" id="4_5wmxq"]
 [ext_resource type="Texture2D" uid="uid://0h57n21pgy7u" path="res://Assets/Clocks/clock_progress_over.png" id="5_org45"]
-[ext_resource type="Texture2D" uid="uid://o7sevo0ogp0" path="res://Assets/ItemBoxes/Wheat_Item_Background_Temp.png" id="6_org45"]
+[ext_resource type="Texture2D" uid="uid://6o5jijuospyl" path="res://Assets/ItemBoxes/Flour_Item_Background_Temp.png" id="6_org45"]
 
 [sub_resource type="AtlasTexture" id="AtlasTexture_2a06r"]
 atlas = ExtResource("2_765ix")

--- a/Scripts/furnace.gd
+++ b/Scripts/furnace.gd
@@ -16,7 +16,6 @@ func _on_biscuit_button_pressed() -> void:
 	if GameManager.inventory != GameManager.Items.DOUGH:
 		return
 	
-	# don't update is_busy, we can leave the biscuits cook unsupervised I guess
 	GameManager.inventory = GameManager.Items.EMPTY
 	$StationProgressRadial.visible = true
 	var winter_multiplier = 1

--- a/Scripts/mixing_bowl.gd
+++ b/Scripts/mixing_bowl.gd
@@ -7,9 +7,17 @@ extends Station
 	
 @export var has_water: bool = false
 @export var has_flour: bool = false
+@export var has_dough: bool = false
 
 	
 func _process(delta: float) -> void:
+	if has_dough:
+		$DoughItemSprite.visible = true
+		$ActionButton.text = "Collect"
+	else:
+		$DoughItemSprite.visible = false
+		$ActionButton.text = "Mix"
+	
 	if has_flour:
 		$FlourItemSprite.visible = true
 	else:
@@ -24,6 +32,11 @@ func _on_mixing_button_pressed() -> void:
 	if $Timer.time_left != 0:
 		return
 	
+	if has_dough:
+		GameManager.gain_dough()
+		has_dough = false
+		return
+	
 	if GameManager.inventory == GameManager.Items.FLOUR and !has_flour:
 		GameManager.inventory = GameManager.Items.EMPTY
 		has_flour = true
@@ -33,18 +46,16 @@ func _on_mixing_button_pressed() -> void:
 		has_water = true
 	
 	if has_water and has_flour:
-		GameManager.is_busy = true
 		$StationProgressRadial.visible = true
 		var winter_multiplier = 1
 		if GameManager.winter_intensity > 0:
 			winter_multiplier = 1.5
 		$Timer.start($Timer.wait_time * winter_multiplier)
+		has_water = false
+		has_flour = false
 
 func _on_timer_timeout() -> void:
-	GameManager.gain_dough()
-	GameManager.is_busy = false
-	has_water = false
-	has_flour = false
+	has_dough = true
 
 func add_flour(flour_to_add: int) -> void:
 	flour_amount += flour_to_add

--- a/Scripts/mortar_and_pestle.gd
+++ b/Scripts/mortar_and_pestle.gd
@@ -3,21 +3,29 @@ extends Station
 @export var wheat_consumed: int = 1
 @export var wheat_amount: int = 0
 
+@export var has_flour: bool = false
+
 func _process(delta: float) -> void:
-	if wheat_amount > 0:
+	if has_flour:
 		$Sprite2D.visible = true
+		$ActionButton.text = "Collect"
 	else:
 		$Sprite2D.visible = false
+		$ActionButton.text = "Crush"
 
 func _on_crush_button_pressed() -> void:
 	if $Timer.time_left != 0:
+		return
+		
+	if has_flour:
+		GameManager.gain_flour()
+		has_flour = false
 		return
 		
 	if GameManager.inventory != GameManager.Items.WHEAT:
 		return
 	
 	GameManager.inventory = GameManager.Items.EMPTY
-	GameManager.is_busy = true
 	$StationProgressRadial.visible = true
 	var winter_multiplier = 1
 	if GameManager.winter_intensity > 0:
@@ -25,8 +33,7 @@ func _on_crush_button_pressed() -> void:
 	$Timer.start($Timer.wait_time * winter_multiplier)
 	
 func _on_timer_timeout() -> void:
-	GameManager.gain_flour()
-	GameManager.is_busy = false
+	has_flour = true
 
 func add_wheat(wheat_to_add: int) -> void:
 	wheat_amount += wheat_to_add

--- a/Scripts/player.gd
+++ b/Scripts/player.gd
@@ -27,10 +27,9 @@ func _physics_process(delta: float) -> void:
 	if standing_in_snow:
 		speed = 110
 	
-	if !GameManager.is_busy:
-		$AnimatedSprite2D.play(anim)
-		velocity = direction * speed
-		move_and_slide()
+	$AnimatedSprite2D.play(anim)
+	velocity = direction * speed
+	move_and_slide()
 
 
 func _on_snow_pile_1_body_entered(body: Node2D) -> void:

--- a/Scripts/water.gd
+++ b/Scripts/water.gd
@@ -15,7 +15,6 @@ func _on_button_pressed() -> void:
 	if GameManager.inventory != GameManager.Items.EMPTY:
 		return
 	
-	GameManager.is_busy = true
 	$StationProgressRadial.visible = true
 	var winter_multiplier = 1
 	if GameManager.winter_intensity > 0:
@@ -24,7 +23,6 @@ func _on_button_pressed() -> void:
 
 func _on_timer_timeout() -> void:
 	GameManager.gain_water()
-	GameManager.is_busy = false
 	quantity -= 1
 	if quantity < 1:
 		# destroy this object

--- a/Scripts/wheat.gd
+++ b/Scripts/wheat.gd
@@ -15,7 +15,6 @@ func _on_harvest_button_pressed() -> void:
 	if GameManager.inventory != GameManager.Items.EMPTY:
 		return
 	
-	GameManager.is_busy = true
 	$StationProgressRadial.visible = true
 	var winter_multiplier = 1
 	if GameManager.winter_intensity > 0:
@@ -24,7 +23,6 @@ func _on_harvest_button_pressed() -> void:
 
 func _on_timer_timeout() -> void:
 	GameManager.gain_wheat()
-	GameManager.is_busy = false
 	quantity -= 1
 	if quantity < 1:
 		# destroy this object

--- a/game_manager.gd
+++ b/game_manager.gd
@@ -5,8 +5,6 @@ extends Node
 enum Items {EMPTY, WHEAT, FLOUR, WATER, DOUGH}
 @export var inventory: int = Items.EMPTY
 
-@export var is_busy: bool = false
-
 @export var turn: int = 1
 @export var player_distance: int = 1000
 @export var winter_distance: int = 0


### PR DESCRIPTION
remove busy status, allow players to move while stations are working,  require them to come back and retrieve items